### PR TITLE
Log failed LDAP connection attempts

### DIFF
--- a/roles/lb_haproxy/templates/haproxy.cfg.j2
+++ b/roles/lb_haproxy/templates/haproxy.cfg.j2
@@ -135,6 +135,7 @@ backend {{host.name}}
 {% for host in lb_ldap %}
 {% set name = "{}{}".format(host.hostname.split('.')[0], "" if loop.index==1 else "{}".format(loop.index)) -%}
 listen {{name}}
+    no option dontlognull
     bind    *:{{host.frontend_port}} ssl crt {{host.hostname}}/priv+fullchain.pem transparent
     bind [::]:{{host.frontend_port}} ssl crt {{host.hostname}}/priv+fullchain.pem transparent
 
@@ -153,7 +154,7 @@ listen {{name}}
       {%- for ip in iprange.get("vpn", {}).values() %} {{ip}}{% endfor %}
       {%- for ip in iprange.get("vpn6",{}).values() %} {{ip}}{% endfor %}
 
-    tcp-request connection reject unless ldap_sbs_allow or ldap_local_allow or ldap_vpn_allow
+    tcp-request content reject unless ldap_sbs_allow or ldap_local_allow or ldap_vpn_allow
 
     timeout client 900s
     timeout server 901s


### PR DESCRIPTION
Resolves https://github.com/SURFscz/SRAM-deploy/issues/293

Failed attempt logs look like this:
`Aug 24 12:01:37 lb haproxy[10787]: 172.20.1.1:58326 [24/Aug/2022:12:01:37.268] ldap_ldap_636~ ldap_ldap_636/<NOSRV> -1/-1/+177 +0 PR 1/1/0/0/3 0/0`

They have `<NOSRV>` instead of a valid backend server.