### PR TITLE
Fix docker cgroupv2 compatibility

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,6 +51,11 @@ RUN systemctl enable ssh.service                 && \
     systemctl disable systemd-timesyncd.service  && \
     echo "exit 0" > /usr/sbin/policy-rc.d
 
+RUN systemctl disable getty@  && \
+    systemctl disable getty.target  && \
+    rm /lib/systemd/system/multi-user.target.wants/getty.target  && \
+    rm /lib/systemd/system/getty.target.wants/getty-static.service
+
 RUN useradd --create-home --shell /bin/bash --groups adm ansible        && \
     install -d -o ansible -m 0700 /home/ansible/.ssh  && \
     echo -n 'ansible:ansible' | chpasswd

--- a/docker/daemon.json
+++ b/docker/daemon.json
@@ -1,0 +1,6 @@
+{
+  "features": { "buildkit": true },
+  "experimental": true,
+  "exec-opts": ["native.cgroupdriver=systemd"],
+  "cgroup-parent": "docker.slice"
+}

--- a/docker/docker-compose.yml.py
+++ b/docker/docker-compose.yml.py
@@ -57,9 +57,9 @@ def host_config(num: int, name: str) -> Dict[str, Any]:
     data: Dict[str, Any] = dict()
     data['image'       ] = 'scz-base'
     data['hostname'    ] =  name
-    data['volumes'     ] = [ './ansible_key.pub:/tmp/authorized_keys', '/sys/fs/cgroup:/sys/fs/cgroup:ro' ]
+    data['volumes'     ] = [ './ansible_key.pub:/tmp/authorized_keys' ]
     data['tmpfs'       ] = [ '/run', '/run/lock', '/tmp' ]
-    data['privileged'  ] = False
+    data['privileged'  ] = True
     data['security_opt'] = [ 'seccomp:unconfined', 'apparmor:unconfined' ]
     data['cap_add'     ] = [ 'SYS_ADMIN', 'SYS_PTRACE' ]
     data['networks'    ] = {

--- a/roles/ci-runner/tasks/main.yml
+++ b/roles/ci-runner/tasks/main.yml
@@ -6,6 +6,7 @@
       - "docker-ce"
       - "docker-ce-cli"
       - "docker-compose"
+      - "docker-compose-plugin"
       - "ansible"
       - "apache2"
 

--- a/start-vm
+++ b/start-vm
@@ -66,7 +66,7 @@ else
     # Bring up the VMs if they're not running
     echo "Bringing docker containers up"
     ./docker/docker-compose.yml.py $CI > ./docker/docker-compose.yml
-    time docker-compose -f docker/docker-compose.yml up --no-recreate -d --remove-orphans
+    time docker compose -f docker/docker-compose.yml up --no-recreate -d --remove-orphans
 
     echo "Waiting until containers have booted"
     TIMEOUT=120


### PR DESCRIPTION
This PR _finally_ resolves cgroupv2 compatibility for our deploy.
I can now do without ```systemd.unified_cgroup_hierarchy=false``` in my ```GRUB_CMDLINE_LINUX``` boot param.

It requires a docker daemon configuration file /etc/docker/daemon.json
```
{
  "features": { "buildkit": true },
  "experimental": true,
  "exec-opts": ["native.cgroupdriver=systemd"],
  "cgroup-parent": "docker.slice"
}
```

But it also requires the containers to be privileged, which is a sad side-effect of docker mounting /sys/fs/cgroup ro when unprivileged, even in a private cgroup slice. And because of that, we need to disable the tty's in de docker, because otherwise the host explodes.

https://serverfault.com/questions/1053187/systemd-fails-to-run-in-a-docker-container-when-using-cgroupv2-cgroupns-priva