### PR TITLE
Fix haproxy SBS health check

### DIFF
--- a/environments/docker/group_vars/container.yml
+++ b/environments/docker/group_vars/container.yml
@@ -83,8 +83,8 @@ loadbalancer:
     backend_hosts: "{{groups['container_docker1']}}"
     backend_port: 443
     options:
-      option: "httpchk"
-      http-check: "send meth GET uri /health ver HTTP/2 hdr Host {{hostnames.sbs}}"
+      option: "httpchk GET /health"
+      http-check: "send ver HTTP/2 hdr Host {{hostnames.sbs}}"
   - name: "meta"
     hostname: "{{hostnames.meta}}"
     protocol: http

--- a/environments/docker/group_vars/container.yml
+++ b/environments/docker/group_vars/container.yml
@@ -83,7 +83,8 @@ loadbalancer:
     backend_hosts: "{{groups['container_docker1']}}"
     backend_port: 443
     options:
-      httpchk: "GET /health"
+      option: "httpchk"
+      http-check: "send meth GET uri /health ver HTTP/2 hdr Host {{hostnames.sbs}}"
   - name: "meta"
     hostname: "{{hostnames.meta}}"
     protocol: http

--- a/environments/vm/group_vars/vm.yml
+++ b/environments/vm/group_vars/vm.yml
@@ -40,7 +40,8 @@ loadbalancer:
     backend_hosts: "{{groups['vm_sbs']}}"
     backend_port: "{{ sbs_backend_port }}"
     options:
-      httpchk: "GET /health"
+      option: "httpchk"
+      http-check: "send meth GET uri /health ver HTTP/2 hdr Host {{hostnames.sbs}}"
   - name: "meta"
     hostname: "{{hostnames.meta}}"
     protocol: http

--- a/environments/vm/group_vars/vm.yml
+++ b/environments/vm/group_vars/vm.yml
@@ -40,8 +40,8 @@ loadbalancer:
     backend_hosts: "{{groups['vm_sbs']}}"
     backend_port: "{{ sbs_backend_port }}"
     options:
-      option: "httpchk"
-      http-check: "send meth GET uri /health ver HTTP/2 hdr Host {{hostnames.sbs}}"
+      option: "httpchk GET /health"
+      http-check: "send ver HTTP/2 hdr Host {{hostnames.sbs}}"
   - name: "meta"
     hostname: "{{hostnames.meta}}"
     protocol: http

--- a/roles/lb_haproxy/templates/haproxy.cfg.j2
+++ b/roles/lb_haproxy/templates/haproxy.cfg.j2
@@ -132,7 +132,7 @@ backend {{host.name}}
     mode http
 {% if host.options is defined %}
 {% for option, value in host.options.items() %}
-    option {{option}} {{value}}
+    {{option}} {{value}}
 {% endfor %}
 {% endif %}
     {% for be_server in host.backend_hosts -%}


### PR DESCRIPTION
Fix the bug that HAproxy wouldn't request the correct hostname from the backend server.  In case of the docker setup, this caused traefik to serve the wrong health endpoint.