### PR TITLE
Fix ci-runner pkgs

### DIFF
--- a/roles/ci-runner/tasks/main.yml
+++ b/roles/ci-runner/tasks/main.yml
@@ -9,6 +9,9 @@
       - "docker-compose-plugin"
       - "ansible"
       - "apache2"
+      - "chromium"
+      - "chromium-common"
+      - "chromium-driver"
 
 - name: "Fix cgroup v1 for docker"
   ansible.builtin.lineinfile:


### PR DESCRIPTION
We never added Chromium(-*) to the required packages, but it defenately needs to be installed when reprovisioning bhr12.
Probably installed by hand during testing?