### PR TITLE
Confine LDAP port expose to localhost

### DIFF
--- a/roles/docker_ldap/tasks/main.yml
+++ b/roles/docker_ldap/tasks/main.yml
@@ -112,7 +112,7 @@
     state: started
     # pull: true
     ports:
-      - 389:1389
+      - 127.0.0.1:389:1389
     #   - 636:1636
     env:
       LDAP_ROOT: "{{ services_ldap.basedn }}"


### PR DESCRIPTION
Expose LDAP container 1389 to localhost:389 on the docker host