### PR TITLE
Improve suspension policy for testing

### DIFF
--- a/environments/docker/group_vars/container.yml
+++ b/environments/docker/group_vars/container.yml
@@ -171,3 +171,8 @@ sbs_ssid_identity_providers:
 
 sbs_notifications_enabled: True
 sbs_cron_hour_of_day: "4"
+
+# Any last_login_date in the past triggers suspension notification
+sbs_suspension_inactive_days: 0
+# Second suspension cron will suspend notified users
+sbs_suspension_reminder_days: -1

--- a/roles/docker_sbs/defaults/main.yml
+++ b/roles/docker_sbs/defaults/main.yml
@@ -92,6 +92,7 @@ sbs_mock_scim_enabled: True
 
 sbs_delete_orphaned: True
 sbs_suspension_inactive_days: 365
+sbs_suspension_reminder_days: 14
 sbs_suspension_notify_admin: False
 
 sbs_oidc_config_url: "http://localhost/.well-known/openid-configuration"

--- a/roles/sbs/defaults/main.yml
+++ b/roles/sbs/defaults/main.yml
@@ -89,6 +89,7 @@ sbs_mock_scim_enabled: False
 
 sbs_delete_orphaned: True
 sbs_suspension_inactive_days: 365
+sbs_suspension_reminder_days: 14
 sbs_suspension_notify_admin: False
 
 sbs_oidc_config_url: "http://localhost/.well-known/openid-configuration"

--- a/roles/sbs/templates/config.yml.j2
+++ b/roles/sbs/templates/config.yml.j2
@@ -154,9 +154,11 @@ user_requests_retention:
 retention:
   cron_hour_of_day: {{ sbs_cron_hour_of_day }}
   # how many days of inactivity before a user is suspended
+  #   0 allows for any last_login_date in the past to trigger suspension notification
   allowed_inactive_period_days: {{ sbs_suspension_inactive_days }}
   # how many days before suspension do we send a warning
-  reminder_suspend_period_days: 14
+  #   -1 will suspend notified users on second suspension cron
+  reminder_suspend_period_days: {{ sbs_suspension_reminder_days }}
   # how many days after suspension do we delete the account
   remove_suspended_users_period_days: 90
   # how many days before deletion do we send a reminder


### PR DESCRIPTION
Improve manual suspension testing of local container deploy.
By assigning `0` to `allowed_inactive_period_days` and `-1` to `reminder_suspend_period_days` we can notify and suspend users in two  consecutive suspend cron runs, including the mails sent to the user when the `last_login_date` of a user is set in the past (manual db action).