### PR TITLE
Fix ansible and haproxy for containers

### DIFF
--- a/roles/lb_haproxy/templates/haproxy.cfg.j2
+++ b/roles/lb_haproxy/templates/haproxy.cfg.j2
@@ -31,7 +31,8 @@ global
 {% endif %}
 
     server-state-file {{haproxy_state_file}}
-    maxconn 256
+    maxconn     4000
+    ulimit-n    9000
 
 defaults
     log     global

--- a/roles/lb_haproxy/templates/haproxy.cfg.j2
+++ b/roles/lb_haproxy/templates/haproxy.cfg.j2
@@ -31,6 +31,7 @@ global
 {% endif %}
 
     server-state-file {{haproxy_state_file}}
+    maxconn 256
 
 defaults
     log     global

--- a/start-vm
+++ b/start-vm
@@ -191,7 +191,7 @@ if [ "$SKIP_ANSIBLE" ]
 then
     echo "Skipping ansible run"
 else
-    ansible-galaxy install -r requirements.yml || ansible-galaxy install --force -r requirements.yml
+    ansible-galaxy collection install -U -r requirements.yml || ansible-galaxy collection install --force -r requirements.yml
     echo "Starting ansible"
 
     export ANSIBLE_FORCE_COLOR=True


### PR DESCRIPTION
Ansible-galaxy collection syntax has changed a little, so it never updated stale packges.

HAproxy was broken on container deploy, because it can not handle maxconn * FD_SETSIZE filehandles (or something along those lines). https://github.com/docker-library/haproxy/issues/180

fd_hard_limit is not available in our version, so had to reduce global.maxconn.
