### PR TITLE
Merge release branch back into main

### DIFF
--- a/roles/backups/tasks/main.yml
+++ b/roles/backups/tasks/main.yml
@@ -7,11 +7,13 @@
       debug:
         var: backup_collector_ssh_key
     - name: Set variable
-      set_fact: vault_decrypted=true
+      ansible.builtin.set_fact:
+        vault_decrypted: true
   rescue:
     - meta: noop
     - name: Set variable
-      set_fact: vault_decrypted=false
+      ansible.builtin.set_fact:
+        vault_decrypted: false
 
 - name: Install tmpreaper
   apt:

--- a/roles/mail/tasks/mailrelay.yml
+++ b/roles/mail/tasks/mailrelay.yml
@@ -43,7 +43,7 @@
 - name: install smarthost relay_credentials
   copy:
     content: |
-      [{{mail.relay_to}}]:{{mail.relay_port}} {{mail_relay_username}}:{{mail_relay_password}}
+      [{{mail.relay_to}}]:{{mail.relay_port}}
     dest: "{{postfix_relay_secret_file}}"
     owner: "root"
     mode: "0600"

--- a/roles/mail/tasks/mailrelay.yml
+++ b/roles/mail/tasks/mailrelay.yml
@@ -48,7 +48,7 @@
     owner: "root"
     mode: "0600"
   no_log: true
-  when: "mail_relay is true"
+  when: "mail_relay is true and mail_relay_password is defined "
   notify:
     - "restart postfix"
 
@@ -63,4 +63,3 @@
     src: "/etc/postfix/aliases"
     state: "link"
     force: true
-

--- a/roles/mail/tasks/mailrelay.yml
+++ b/roles/mail/tasks/mailrelay.yml
@@ -43,7 +43,7 @@
 - name: install smarthost relay_credentials
   copy:
     content: |
-      [{{mail.relay_to}}]:{{mail.relay_port}}
+      [{{mail.relay_to}}]:{{mail.relay_port}} {{mail_relay_username}}:{{mail_relay_password}}
     dest: "{{postfix_relay_secret_file}}"
     owner: "root"
     mode: "0600"


### PR DESCRIPTION
When deploying from my local pc with a new Ansible version, it breaks because the old set_fact syntax is now deprecated. Refactored it so it is now the official Ansible syntax.

This merge request only needs to be merged **after** v44 has been released to prod.