### PR TITLE
Disable HTTP caching for SBS index.html

### DIFF
--- a/roles/docker_sbs/templates/sbs-apache.conf.j2
+++ b/roles/docker_sbs/templates/sbs-apache.conf.j2
@@ -17,11 +17,14 @@ ProxyPassReverse / http://{{ containers.sbs_server }}:{{sbs_backend_port}}/
 ProxyPass /socket.io/ ws://{{ containers.sbs_server }}:{{sbs_backend_port}}/socket.io/
 ProxyPassReverse /socket.io/ ws://{{ containers.sbs_server }}:{{sbs_backend_port}}/socket.io/
 
-<If "%{REQUEST_URI} =~ m#^/api/images/#">
-    Header set Cache-Control:  "public, max-age=31536000, immutable"
+<If "%{REQUEST_URI} == '/' || %{REQUEST_URI} == '/index.html'">
+    Header set Cache-Control "no-cache, private"
 </If>
+<ElseIf "%{REQUEST_URI} =~ m#^/api/images/#">
+    Header set Cache-Control "public, max-age=31536000, immutable"
+</ElseIf>
 <ElseIf "%{REQUEST_URI} =~ m#^/(api|pam-weblogin|flasgger_static|swagger|health|config|info)#">
-    Header set Cache-Control:  "no-cache, private"
+    Header set Cache-Control "no-cache, private"
 </ElseIf>
 
 <Directory /opt/sbs/client/dist>

--- a/roles/docker_sbs/templates/sbs-apache.conf.j2
+++ b/roles/docker_sbs/templates/sbs-apache.conf.j2
@@ -18,7 +18,7 @@ ProxyPass /socket.io/ ws://{{ containers.sbs_server }}:{{sbs_backend_port}}/sock
 ProxyPassReverse /socket.io/ ws://{{ containers.sbs_server }}:{{sbs_backend_port}}/socket.io/
 
 <If "%{REQUEST_URI} == '/' || %{REQUEST_URI} == '/index.html'">
-    Header set Cache-Control "no-cache, private"
+    Header set Cache-Control "no-store"
 </If>
 <ElseIf "%{REQUEST_URI} =~ m#^/api/images/#">
     Header set Cache-Control "public, max-age=31536000, immutable"

--- a/roles/sbs/templates/sbs-nginx.j2
+++ b/roles/sbs/templates/sbs-nginx.j2
@@ -32,6 +32,7 @@ server {
 
     location @index {
         rewrite ^ /index.html;
+        add_header Cache-Control "nocache, private";
     }
 
     location ~ /(api|pam-weblogin|flasgger_static|swagger|health|config|info) {

--- a/roles/sbs/templates/sbs-nginx.j2
+++ b/roles/sbs/templates/sbs-nginx.j2
@@ -32,7 +32,10 @@ server {
 
     location @index {
         rewrite ^ /index.html;
-        add_header Cache-Control "nocache, private";
+    }
+
+    location /index.html {
+         add_header Cache-Control "no-store";
     }
 
     location ~ /(api|pam-weblogin|flasgger_static|swagger|health|config|info) {
@@ -43,7 +46,7 @@ server {
         proxy_hide_header Content-Security-Policy;
         add_header Content-Security-Policy $csp;
         proxy_hide_header Cache-Control;
-        add_header Cache-Control "nocache, private";
+        add_header Cache-Control "nocache, private";  # should be "no-cache" ("nocache" is silently ignored)
     }
 
     location ^~ /api/images {


### PR DESCRIPTION
This prevents problems during and after deploy, when old assets names could disappear.