### PR TITLE
Enable tag deployment

### DIFF
--- a/surf-deploy
+++ b/surf-deploy
@@ -82,7 +82,7 @@ echo "$0 $*" >> $LOG
  else
      echo -e "$OK"
  fi
- branch_deploy=$(git symbolic-ref HEAD 2> /dev/null || git describe --exact)
+ branch_deploy=$(git symbolic-ref HEAD 2> /dev/null || git tag --points-at HEAD)
 
  # config
  cwd=$(pwd)
@@ -97,7 +97,7 @@ echo "$0 $*" >> $LOG
  else
      echo -e "$OK"
  fi
- branch_config=$(git symbolic-ref HEAD 2> /dev/null || git describe --exact)
+ branch_config=$(git symbolic-ref HEAD 2> /dev/null || git tag --points-at HEAD)
  cd "$cwd"
 
  echo -n "Checking whether deploy and config are in sync... "


### PR DESCRIPTION
git describe --exact does not work for some reason, directly taking the tag seems to work better. My hypothesis would be that normally the release branches are used instead of releasing old tags. If releasing old tags is very common, it could be an error on my machine, in that case don't approve