### PR TITLE
SURFstar IdP fixes

### DIFF
--- a/roles/simplesamlphp/tasks/main.yml
+++ b/roles/simplesamlphp/tasks/main.yml
@@ -40,6 +40,7 @@
     shell: "/usr/sbin/nologin"
     system: true
     password: "!"
+    state: "present"
 
 - name: Create simplesaml project dirs
   file:

--- a/roles/surfstar-idp/tasks/main.yml
+++ b/roles/surfstar-idp/tasks/main.yml
@@ -26,6 +26,11 @@
 - include_role:
     name: "simplesamlphp"
     public: true
+  vars:
+    simplesaml_name: "{{surfstar_idp_name}}"
+    simplesaml_user: "{{surfstar_idp_user}}"
+    simplesaml_group: "{{surfstar_idp_group}}"
+    simplesaml_project_dir: "{{surfstar_idp_dir}}"
 
 - name: SimpleSaml configuration (templates)
   template:


### PR DESCRIPTION
This is the current state of bhr13. bhr13 is not deployed often, and a bug occurred when trying to deploy it recently. Surfstar IdP variables were not used, so the process was started with the default user. Ansible later tried change the user while the php fpm process with the real surfstar was running, but then this clashes with the running process. This fixes that.